### PR TITLE
Randomize startup delay of systemd timers and version bump

### DIFF
--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maik Broemme <mbroemme@libmpq.org>
 pkgname="nodejs-galilel-explorer"
 pkgdesc="Galilel Explorer"
-pkgver=0.1.1
+pkgver=0.1.2
 pkgrel=1
 arch=("any")
 url="https://explorer.galilel.org"

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-block.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-block.timer
@@ -3,6 +3,7 @@ Description = Galilel Explorer (Sync) - Blockchain update timer
 
 [Timer]
 OnCalendar = *:0/1
+RandomizedDelaySec = 5
 Persistent = true
  
 [Install]

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-coin.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-coin.timer
@@ -3,6 +3,7 @@ Description = Galilel Explorer (Sync) - Coin information update timer
 
 [Timer]
 OnCalendar = *:0/5
+RandomizedDelaySec = 30
 Persistent = true
  
 [Install]

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-masternode.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-masternode.timer
@@ -3,6 +3,7 @@ Description = Galilel Explorer (Sync) - Masternode update timer
 
 [Timer]
 OnCalendar = *:0/1
+RandomizedDelaySec = 5
 Persistent = true
  
 [Install]

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-peer.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-peer.timer
@@ -3,6 +3,7 @@ Description = Galilel Explorer (Sync) - Network peers update timer
 
 [Timer]
 OnCalendar = *:0/1
+RandomizedDelaySec = 5
 Persistent = true
  
 [Install]

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-rich.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-rich.timer
@@ -3,6 +3,7 @@ Description = Galilel Explorer (Sync) - Rich list update timer
 
 [Timer]
 OnCalendar = *:0/1
+RandomizedDelaySec = 5
 Persistent = true
  
 [Install]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galilel-explorer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Galilel Explorer",
   "main": "public",
   "repository": "git@github.com:Galilel-Project/galilel-explorer.git",


### PR DESCRIPTION
Startup delay of systemd timers should use RandomizedDelaySec to avoid simultaneous startup of all timers. Also lets increase version to 0.1.2 with all merges from PR #1.