### PR TITLE
Fixes for v0.1.3

### DIFF
--- a/client/component/Card/CardAddressTXs.jsx
+++ b/client/component/Card/CardAddressTXs.jsx
@@ -57,7 +57,7 @@ export default class CardAddressTXs extends Component {
             amount: (
               <span
                 className="badge badge-transaction-amount badge-right">
-                { numeral(amount).format(config.coinDetails.coinNumberFormat) } { config.coinDetails.shortName }
+                { numeral(amount).format(config.coinDetails.coinNumberFormat) }
               </span>
             ),
             createdAt: (

--- a/client/component/Card/CardAddressTXs.jsx
+++ b/client/component/Card/CardAddressTXs.jsx
@@ -56,9 +56,8 @@ export default class CardAddressTXs extends Component {
             ...tx,
             amount: (
               <span
-                className={ `badge badge-${ isSpent ? 'danger-monospace' : 'success-monospace' } badge-right` }>
-                { isSpent ? numeral(-amount).format(config.coinDetails.coinNumberFormatFinance) :
-                            numeral(amount).format(config.coinDetails.coinNumberFormatFinance) } { config.coinDetails.shortName }
+                className="badge badge-transaction-amount badge-right">
+                { numeral(amount).format(config.coinDetails.coinNumberFormat) } { config.coinDetails.shortName }
               </span>
             ),
             createdAt: (

--- a/client/component/Card/CardBlockRewardDetailsStaking.jsx
+++ b/client/component/Card/CardBlockRewardDetailsStaking.jsx
@@ -52,7 +52,7 @@ export default class CardBlockRewardDetailsStaking extends Component {
           <div className="card__row">
             <span className="card__label">Stake Reward:</span>
             <span className="card__result">
-              {this.getBlockRewardLink(blockRewardDetails)}
+              {numeral(blockRewardDetails.stake.reward).format(config.coinDetails.coinNumberFormat)} {config.coinDetails.shortName}
             </span>
           </div>
           <div className="card__row">
@@ -62,6 +62,12 @@ export default class CardBlockRewardDetailsStaking extends Component {
           <div className="card__row">
             <span className="card__label">Stake Input Confirmations:</span>
             <span className="card__result">{inputConfirmations}</span>
+          </div>
+          <div className="card__row">
+            <span className="card__label">Restake Amount:</span>
+            <span className="card__result">
+              {this.getBlockRewardLink(blockRewardDetails)}
+            </span>
           </div>
           <div className="card__row">
             <span className="card__label">PoS Profitability Score:</span>

--- a/client/component/Card/CardRewards.jsx
+++ b/client/component/Card/CardRewards.jsx
@@ -72,7 +72,7 @@ export default class CardRewards extends Component {
         ),
         posReward: (
           <Link to={this.getRewardLink(reward)}>
-            <span className={`badge badge-${reward.stake.reward < 0 ? 'danger-monospace' : 'success-monospace'}`}>
+            <span className="badge badge-transaction-amount">
               {numeral(reward.stake.reward).format(config.coinDetails.coinNumberFormat)}
             </span>
           </Link>
@@ -89,7 +89,7 @@ export default class CardRewards extends Component {
         ),
         masternodeReward: (
           <Link to={this.getRewardLink(reward)}>
-            <span className={`badge badge-${reward.masternode.reward < 0 ? 'danger-monospace' : 'success-monospace'}`}>
+            <span className="badge badge-transaction-amount">
               {numeral(reward.masternode.reward).format(config.coinDetails.coinNumberFormat)}
             </span>
           </Link>

--- a/client/component/Card/CardTXIn.jsx
+++ b/client/component/Card/CardTXIn.jsx
@@ -74,7 +74,7 @@ export default class CardTXIn extends Component {
           value: tx.relatedVout
             ? (
                 <span className="badge badge-danger-monospace badge-right">
-                {numeral(-tx.relatedVout.value).format(config.coinDetails.coinNumberFormatFinance)} {config.coinDetails.shortName}
+                {numeral(-tx.relatedVout.value).format(config.coinDetails.coinNumberFormatFinance)}
                 </span>
               )
             : 'N/A'

--- a/client/component/Card/CardTXOut.jsx
+++ b/client/component/Card/CardTXOut.jsx
@@ -40,7 +40,7 @@ export default class CardTXOut extends Component {
           ),
           value: (
             <span className="badge badge-success-monospace badge-right">
-              {numeral(tx.value).format(config.coinDetails.coinNumberFormatFinance)} {config.coinDetails.shortName}
+              {numeral(tx.value).format(config.coinDetails.coinNumberFormatFinance)}
             </span>
           )
         }))} />

--- a/client/component/Card/CardTXs.jsx
+++ b/client/component/Card/CardTXs.jsx
@@ -60,7 +60,7 @@ export default class CardTXs extends Component {
             ),
             vout: (
               <Link to={`/tx/${tx.txId}`}>
-                <span className={`badge badge-${blockValue < 0 ? 'danger-monospace' : 'success-monospace'} badge-right`}>
+                <span className="badge badge-transaction-amount badge-right">
                   {TransactionValue(tx, blockValue)}
                 </span>
               </Link>

--- a/client/container/Overview.jsx
+++ b/client/container/Overview.jsx
@@ -60,7 +60,7 @@ class Overview extends Component {
         ),
         vout: (
           <Link to={`/tx/${tx.txId}`}>
-            <span className={`badge badge-${blockValue < 0 ? 'danger-monospace' : 'success-monospace'} badge-right`}>
+            <span className="badge badge-transaction-amount badge-right">
               {TransactionValue(tx, blockValue)}
             </span>
           </Link>

--- a/client/container/Top100.jsx
+++ b/client/container/Top100.jsx
@@ -58,7 +58,7 @@ class Top100 extends Component {
             ),
             value: (
               <Link to={`/address/${wallet.address}`}>
-                <span className={`badge badge-${wallet.value < 0 ? 'danger-monospace' : 'success-monospace'} badge-right`}>
+                <span className="badge badge-transaction-amount badge-right">
                   {numeral(wallet.value).format(config.coinDetails.coinNumberFormat)}
                 </span>
               </Link>

--- a/client/theme.scss
+++ b/client/theme.scss
@@ -179,7 +179,6 @@ hr {
     font-family: monospace;
     background-color: $red;
     border-radius: 2px;
-    color: $light-brown-3;
     padding: .2em .6em;
   }
 
@@ -188,7 +187,14 @@ hr {
     font-family: monospace;
     background-color: $green;
     border-radius: 2px;
-    color: $black;
+    padding: .2em .6em;
+  }
+
+  &-transaction-amount {
+    color: $grey-10-black !important;
+    font-family: monospace;
+    background-color: $dark-brown-3;
+    border-radius: 2px;
     padding: .2em .6em;
   }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jquery": "3.4.1",
     "lodash": "^4.17.5",
     "moment": "^2.20.1",
-    "mongoose": "5.6.0",
+    "mongoose": "5.0.6",
     "morgan": "^1.9.0",
     "node-bitcoin-rpc": "^1.1.3",
     "numeral": "^2.0.6",


### PR DESCRIPTION
Fixes for 0.1.3:

- Added 'badge-transaction-amount' to have neutral representation in richlist and transaction table
- Added back support for fetching correct balance and received amounts
- No need to add GALI in every amount or value, it is clear enough
- Added support for showing stake reward and restake amount
- Use 'badge-transaction-amount' in overview, movement and rewards
- Switched mongoose back to 5.0.6 version