### PR TITLE
Urgent fix for deprecation warning and bump version to 0.1.4

### DIFF
--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maik Broemme <mbroemme@libmpq.org>
 pkgname="nodejs-galilel-explorer"
 pkgdesc="Galilel Explorer"
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 arch=("any")
 url="https://explorer.galilel.org"

--- a/lib/db.js
+++ b/lib/db.js
@@ -18,8 +18,7 @@ const getOptions = () => {
     native_parser: true,
     pass: config_private.db.pass,
     promiseLibrary: promise,
-    user: config_private.db.user,
-    useNewUrlParser: true
+    user: config_private.db.user
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galilel-explorer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Galilel Explorer",
   "main": "public",
   "repository": "git@github.com:Galilel-Project/galilel-explorer.git",


### PR DESCRIPTION
- We downgraded mongoose in 71614e4d57846327dadd6a5f5623e017ac408562 which lead
  to the unsupported option warning.

- Bump version to 0.1.4