### PR TITLE
Urgent fix to sync broken Zerocoin spends while skipping 'OP_ZEROCOINSPEND'

### DIFF
--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maik Broemme <mbroemme@libmpq.org>
 pkgname="nodejs-galilel-explorer"
 pkgdesc="Galilel Explorer"
-pkgver=0.1.4
+pkgver=0.1.5
 pkgrel=1
 arch=("any")
 url="https://explorer.galilel.org"

--- a/cron/util.js
+++ b/cron/util.js
@@ -207,7 +207,7 @@ async function performDeepTxAnalysis(block, rpctx, txDetails) {
   // If our config allows us to extract additional reward data
   if (!!config.splitRewardsData) {
     // If this is a rewards transaction fetch the pos & masternode reward details
-    if (txDetails.isReward) {
+    if (txDetails.isReward && rpctx.vin[0].scriptSig.asm !== 'OP_ZEROCOINSPEND') {
 
       const currentTxTime = rpctx.time;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galilel-explorer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Galilel Explorer",
   "main": "public",
   "repository": "git@github.com:Galilel-Project/galilel-explorer.git",


### PR DESCRIPTION
This fix will solve problem with sync of broken Zerocoin transactions. It
happenend in testnet already because we test a lot of new functionality
and exploits there. Without the fix, sync will stop with:

getrawtransaction { code: -5,
  message: 'No such mempool or blockchain transaction. Use gettransaction for wallet transactions.' }
Fri, 26 Jul 2019 12:23:42 GMT	 Error: [object Object]
    at rpc.call (/root/explorer/galilel-explorer-test/lib/rpc.js:51:18)
    at IncomingMessage.<anonymous> (/root/explorer/galilel-explorer-test/node_modules/node-bitcoin-rpc/lib/index.js:74:9)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)

Must be included in version 0.1.5.