### PR TITLE
 Fixed 'Error: Cannot read property 'total' of undefined'

### DIFF
--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maik Broemme <mbroemme@libmpq.org>
 pkgname="nodejs-galilel-explorer"
 pkgdesc="Galilel Explorer"
-pkgver=0.1.5
+pkgver=0.1.6
 pkgrel=1
 arch=("any")
 url="https://explorer.galilel.org"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galilel-explorer",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Galilel Explorer",
   "main": "public",
   "repository": "git@github.com:Galilel-Project/galilel-explorer.git",

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -91,8 +91,8 @@ const getAddress = async (req, res) => {
     const txs = await qtxs;
     const utxo = await qutxo;
 
-    const balance = utxoFull[0].total;
-    const received = txsFull[0].total;
+    const balance = (utxoFull[0] !== undefined) ? utxoFull[0].total : 0;
+    const received = (txsFull[0] !== undefined) ? txsFull[0].total : 0;
 
     res.json({ balance, received, txs, utxo, isMasternode });
   } catch (err) {


### PR DESCRIPTION
While re-adding back the full balance of a wallet address since genesis block, we introduced some temporary queries. They are undefined if the address is not in UTXO and TX DB. This will lead to error like:

![image](https://user-images.githubusercontent.com/936659/61958817-64225a80-afc2-11e9-95af-c9204662517a.png)

This commit will fix it.