### PR TITLE
Fixed UTXO syncing

### DIFF
--- a/cron/block.js
+++ b/cron/block.js
@@ -35,7 +35,7 @@ async function syncBlocks(start, stop, clean = false) {
   if (clean) {
     await Block.remove({ height: { $gt: start, $lte: stop } });
     await TX.remove({ blockHeight: { $gt: start, $lte: stop } });
-    await UTXO.remove({ blockHeight: { $gte: start, $lte: stop } });  // We will remove this in next patch
+    await UTXO.remove({ blockHeight: { $gt: start, $lte: stop } });
     await BlockRewardDetails.remove({ blockHeight: { $gt: start, $lte: stop } });
   }
 


### PR DESCRIPTION
Urgent fix for UTXO syncing. When DB Height = RPC Height there is a possibility that sync will remove a UTXO row during cleanup.