### PR TITLE
Added governance support for syncing budget proposals and frontend tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,20 @@ update. First time you need to do initial sync of the blockchain via
 
    `npm run cron:masternode`
 
-3. Gather the list of peers and fetch geographical IP information.
+3. Generate the list of budget proposals in the database with the most recent
+   information, clearing old information before.
+
+   `npm run cron:proposal`
+
+4. Gather the list of peers and fetch geographical IP information.
 
    `npm run cron:peer`
 
-4. Sync blocks and transactions by storing them in the database.
+5. Sync blocks and transactions by storing them in the database.
 
    `npm run cron:block`
 
-5. Generate the rich list.
+6. Generate the rich list.
 
    `npm run cron:rich`
 
@@ -107,6 +112,7 @@ the following lines (edit with your local information):
 ```
 */1 * * * * cd /path/to/galilel-explorer && /path/to/node cron/block.js >> tmp/block.log 2>&1
 */1 * * * * cd /path/to/galilel-explorer && /path/to/node cron/masternode.js >> tmp/masternode.log 2>&1
+*/5 * * * * cd /path/to/galilel-explorer && /path/to/node cron/proposal.js >> tmp/proposal.log 2>&1
 */1 * * * * cd /path/to/galilel-explorer && /path/to/node cron/peer.js >> tmp/peer.log 2>&1
 */1 * * * * cd /path/to/galilel-explorer && /path/to/node cron/rich.js >> tmp/rich.log 2>&1
 */5 * * * * cd /path/to/galilel-explorer && /path/to/node cron/coin.js >> tmp/coin.log 2>&1

--- a/client/App.jsx
+++ b/client/App.jsx
@@ -22,6 +22,7 @@ import CoinInfo from './container/CoinInfo';
 import Error404 from './container/Error404';
 import FAQ from './container/FAQ';
 import Masternode from './container/Masternode';
+import Governance from './container/Governance';
 import Movement from './container/Movement';
 import Overview from './container/Overview';
 import Rewards from './container/Rewards';
@@ -180,6 +181,7 @@ class App extends Component {
                   <Route exact path="/coin" component={ CoinInfo } />
                   <Route exact path="/faq" component={ FAQ } />
                   <Route exact path="/masternode" component={ Masternode } />
+                  <Route exact path="/governance" component={ Governance } />
                   <Route exact path="/rewards" component={ Rewards } />
                   <Route exact path="/movement" component={ Movement } />
                   <Route exact path="/peer" component={ Peer } />

--- a/client/component/Menu/menuData.js
+++ b/client/component/Menu/menuData.js
@@ -3,6 +3,7 @@ const MenuData = [
   {label: 'Movement', icon: '/img/movement_mobile.svg', href: '/movement'},
   {label: 'Top 100', icon: '/img/top100_mobile.svg', href: '/top'},
   {label: 'Masternode', icon: '/img/masternodes_mobile.svg', href: '/masternode'},
+  {label: 'Governance', icon: '/img/governance_mobile.svg', href: '/governance'},
   {label: 'Rewards', icon: '/img/rewards_mobile.svg', href: '/rewards'},
   {label: 'Connections', icon: '/img/connections_mobile.svg', href: '/peer'},
   {label: 'Statistics', icon: '/img/statistics_mobile.svg', href: '/statistics'},

--- a/client/container/Governance.jsx
+++ b/client/container/Governance.jsx
@@ -1,0 +1,174 @@
+import Actions from '../core/Actions';
+import Component from '../core/Component';
+import throttle from '../../lib/throttle';
+import { connect } from 'react-redux';
+import { dateFormat } from '../../lib/date';
+import { Link } from 'react-router-dom';
+import moment from 'moment';
+import numeral from 'numeral';
+import PropTypes, { oneOf } from 'prop-types';
+import React from 'react';
+import sortBy from 'lodash/sortBy';
+
+import HorizontalRule from '../component/HorizontalRule';
+import Pagination from '../component/Pagination';
+import Table from '../component/Table';
+import Select from '../component/Select';
+
+import { PAGINATION_PAGE_SIZE } from '../constants';
+
+class Governance extends Component {
+  static propTypes = {
+    getPPs: PropTypes.func.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.debounce = null;
+    this.state = {
+      cols: [
+        { key: 'name', title: 'Name' },
+        { key: 'blockStart', title: 'Start' },
+        { key: 'blockEnd', title: 'End' },
+        { key: 'budgetMonthly', title: (
+          <span className="badge-right">Monthly</span>
+        )},
+        { key: 'budgetPaid', title: (
+          <span className="badge-right">Paid</span>
+        )},
+        { key: 'budgetTotal', title: (
+          <span className="badge-right">Total</span>
+        )},
+        { key: 'yeas', title: (
+          <span className="badge-right">Yeas</span>
+        )},
+        { key: 'nays', title: (
+          <span className="badge-right">Nays</span>
+        )},
+        { key: 'status', title: 'Funded' }
+      ],
+      error: null,
+      loading: true,
+      pps: [] ,
+      pages: 0,
+      page: 1,
+      size: 10
+    };
+
+    this.getThrottledPps = throttle(() => {
+      this.props.getPPs({
+        limit: this.state.size,
+        skip: (this.state.page - 1) * this.state.size
+      }).then(({ pps, pages }) => {
+        this.setState({ pps, pages, loading: false });
+      })
+      .catch(error => this.setState({ error, loading: false }));
+    }, 800);
+
+  };
+
+  componentDidMount() {
+    this.getPPs();
+  };
+
+  componentWillUnmount() {
+    if (this.getThrottledPps) {
+      clearTimeout(this.getThrottledPps);
+    }
+  };
+
+  getPPs = () => {
+    this.setState({ loading: true }, () => {
+      this.getThrottledPps();
+    });
+  };
+
+  handlePage = page => this.setState({ page }, this.getPPs);
+  handleSize = size => this.setState({ size, page: 1 }, this.getPPs);
+
+  render() {
+    if (!!this.state.error) {
+      return this.renderError(this.state.error);
+    } else if (this.state.loading) {
+      return this.renderLoading();
+    }
+    const selectOptions = PAGINATION_PAGE_SIZE;
+
+    const getPaginationDropdown = () => {
+      return (
+        <Select
+          onChange={ value => this.handleSize(value) }
+          selectedValue={ this.state.size }
+          options={ selectOptions } />
+      );
+    };
+
+    return (
+      <div>
+        <HorizontalRule
+          select={ getPaginationDropdown() }
+          title="Current Proposals" />
+        <Table
+          header={ this.state.cols }
+          data={ this.state.pps.map((pp) => {
+            var isFunded = "No"
+            if (pp.status == true) {
+              isFunded = "Yes";
+            }
+            return {
+              ...pp,
+              name: (
+                <a href={`${pp.url}`} target="_blank">
+                  {pp.name}
+                </a>
+              ),
+              blockStart: pp.blockStart,
+              blockEnd: pp.blockEnd,
+              budgetMonthly: (
+                <span className="badge badge-transaction-amount badge-right">
+                  {numeral(pp.budgetMonthly).format(config.coinDetails.coinNumberFormat)}
+                </span>
+              ),
+              budgetPaid: (
+                <span className="badge badge-transaction-amount badge-right">
+                  {numeral(pp.budgetTotal - pp.budgetMonthly * pp.budgetPeriod).format(config.coinDetails.coinNumberFormat)}
+                </span>
+              ),
+              budgetTotal: (
+                <span className="badge badge-transaction-amount badge-right">
+                  {numeral(pp.budgetTotal).format(config.coinDetails.coinNumberFormat)}
+                </span>
+              ),
+              yeas: (
+                <span className="badge badge-success badge-right">
+                  {pp.yeas}
+                </span>
+              ),
+              nays: (
+                <span className="badge badge-danger badge-right">
+                  {pp.nays}
+                </span>
+              ),
+              status: (
+                <span className={ `badge badge-${pp.status ? 'success' : 'danger' }` }>
+                  {isFunded}
+                </span>
+              )
+            };
+          })} />
+        <Pagination
+          current={ this.state.page }
+          className="float-right"
+          onPage={ this.handlePage }
+          total={ this.state.pages } />
+        <div className="clearfix" />
+      </div>
+    );
+  };
+}
+
+const mapDispatch = dispatch => ({
+  getPPs: query => Actions.getPPs(query)
+});
+
+export default connect(null, mapDispatch)(Governance);

--- a/client/core/Actions.jsx
+++ b/client/core/Actions.jsx
@@ -91,6 +91,12 @@ export const getMNs = (query) => {
   });
 };
 
+export const getPPs = (query) => {
+  return new promise((resolve, reject) => {
+    return getFromWorker('pps', api_url, resolve, reject, query);
+  });
+};
+
 export const getPeers = () => {
   return new promise((resolve, reject) => {
     return getFromWorker(
@@ -228,6 +234,7 @@ export default {
   getCoinsWeek,
   getIsBlock,
   getMNs,
+  getPPs,
   getPeers,
   getSupply,
   getTop100,

--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maik Broemme <mbroemme@libmpq.org>
 pkgname="nodejs-galilel-explorer"
 pkgdesc="Galilel Explorer"
-pkgver=0.1.6
+pkgver=0.2.0
 pkgrel=1
 arch=("any")
 url="https://explorer.galilel.org"

--- a/contrib/packages/archlinux/PKGBUILD
+++ b/contrib/packages/archlinux/PKGBUILD
@@ -23,6 +23,8 @@ source=(
   "${pkgname}-sync-masternode.timer"
   "${pkgname}-sync-peer.service"
   "${pkgname}-sync-peer.timer"
+  "${pkgname}-sync-proposal.service"
+  "${pkgname}-sync-proposal.timer"
   "${pkgname}-sync-rich.service"
   "${pkgname}-sync-rich.timer"
 )
@@ -38,6 +40,8 @@ sha256sums=(
   "413ec5843c21b4c5b379fde96388727b4435748221e2724995fbbc1738e01b80"
   "4a53b30e9a9031ac5f23d54ae466ff3a49be4f244e526e72b31c27738b746346"
   "c9f2182030a483826182cfc86391d53218c9f0177e219bc83643e986575ff92b"
+  "8e00cd0e0d194d4dc9462a66c3a9e7168797b2b860aa43f3a85eccc48038760b"
+  "eefe48f44d24940bdf3da689d85fcebba44941894cf5adbcb6ed07d58747cad8"
   "64a70b517c009b8b6b32741b07d8c3fb72df909a2b7d88ea926010e34dcefc24"
   "8af2515c4fbfb144f744e7c96aed5ea49622dd2705bbb05f2235750f1f2d2be3"
 )
@@ -71,6 +75,8 @@ package() {
   install -D -m 0644 "${srcdir}/${pkgname}-sync-masternode.timer" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-masternode.timer"
   install -D -m 0644 "${srcdir}/${pkgname}-sync-peer.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-peer.service"
   install -D -m 0644 "${srcdir}/${pkgname}-sync-peer.timer" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-peer.timer"
+  install -D -m 0644 "${srcdir}/${pkgname}-sync-proposal.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-proposal.service"
+  install -D -m 0644 "${srcdir}/${pkgname}-sync-proposal.timer" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-proposal.timer"
   install -D -m 0644 "${srcdir}/${pkgname}-sync-rich.service" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-rich.service"
   install -D -m 0644 "${srcdir}/${pkgname}-sync-rich.timer" "${pkgdir}/usr/lib/systemd/system/${pkgname}-sync-rich.timer"
   ln -s "/etc/nodejs/galilel-explorer/config.js" "${pkgdir}/usr/lib/node_modules/galilel-explorer/public/config.js"

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-proposal.service
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-proposal.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = Galilel Explorer (Sync) - Proposal update
+
+[Service]
+Type = simple
+WorkingDirectory = /usr/lib/node_modules/galilel-explorer
+ExecStart = /usr/bin/node cron/proposal.js
+SyslogIdentifier = galilel-explorer
+StandardOutput = syslog
+StandardError = syslog

--- a/contrib/packages/archlinux/nodejs-galilel-explorer-sync-proposal.timer
+++ b/contrib/packages/archlinux/nodejs-galilel-explorer-sync-proposal.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description = Galilel Explorer (Sync) - Proposal update timer
+
+[Timer]
+OnCalendar = *:0/5
+RandomizedDelaySec = 5
+Persistent = true
+ 
+[Install]
+WantedBy = timers.target

--- a/cron/proposal.js
+++ b/cron/proposal.js
@@ -1,0 +1,68 @@
+require('babel-polyfill');
+require('../lib/cron');
+const config = require('../public/config');
+const { exit, rpc } = require('../lib/cron');
+const fetch = require('../lib/fetch');
+const { forEach } = require('p-iteration');
+const locker = require('../lib/locker');
+const moment = require('moment');
+// Models.
+const Proposal = require('../model/proposal');
+
+async function syncProposal() {
+    await Proposal.remove({});
+
+    rpc.timeout(10000); // 10 secs
+
+    const pps = await rpc.call('getbudgetinfo');
+    const mnc = await rpc.call('getmasternodecount');
+    const inserts = [];
+    await forEach(pps, async(pp) => {
+        const proposal = new Proposal({
+            name: pp.Name,
+            yeas: pp.Yeas,
+            nays: pp.Nays,
+            blockStart: pp.BlockStart,
+            blockEnd: pp.BlockEnd,
+            status: ((pp.Yeas - pp.Nays) * 10 > mnc.total),
+            budgetTotal: pp.TotalPayment,
+            budgetMonthly: pp.MonthlyPayment,
+            budgetPeriod: pp.RemainingPaymentCount,
+            hash: pp.Hash,
+            feehash: pp.FeeHash,
+            url: pp.URL,
+        });
+
+        inserts.push(proposal);
+    });
+
+    if (inserts.length) {
+        await Proposal.insertMany(inserts);
+    }
+}
+
+/**
+ * Handle locking.
+ */
+async function update() {
+    const type = 'proposal';
+    let code = 0;
+
+    try {
+        locker.lock(type);
+        await syncProposal();
+    } catch (err) {
+        console.log(err);
+        code = 1;
+    } finally {
+        try {
+            locker.unlock(type);
+        } catch (err) {
+            console.log(err);
+            code = 1;
+        }
+        exit(code);
+    }
+}
+
+update();

--- a/lib/fetch.worker.js
+++ b/lib/fetch.worker.js
@@ -1,4 +1,3 @@
-
 /**
  * Web Worker
  * Handles the requesting of data in a separate thread
@@ -65,6 +64,9 @@ const getTXsWeek = (api, query) => fetch(`${api}/tx/week`, query);
 // Request the latest transactions.
 const getTXsLatest = (api, query) => fetch(`${api}/tx/latest`, query);
 
+// Request Proposal data
+const getProposalsData = (api, query) => fetch(`${ api }/proposals`, query);
+
 // Handle incoming messages.
 self.addEventListener('message', (ev) => {
   let action = null;
@@ -110,6 +112,9 @@ self.addEventListener('message', (ev) => {
       break;
     case 'txs-week':
       action = getTXsWeek;
+      break;
+    case 'pps':
+      action = getProposalsData;
       break;
   }
 

--- a/model/proposal.js
+++ b/model/proposal.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+/*
+ * proposal
+ */
+const Proposal = mongoose.model('Proposal', new mongoose.Schema({
+    __v: { select: false, type: Number },
+    id: { index: true, required: false, type: Number },
+    creator: { required: false, type: String },
+    name: { required: true, type: String },
+    yeas: { required: true, type: Number },
+    nays: { required: true, type: Number },
+    blockStart: { required: true, type: Number },
+    blockEnd: { required: true, type: Number },
+    status: { required: true, type: Boolean },
+    budgetTotal: { required: true, type: Number },
+    budgetMonthly: { required: true, type: Number },
+    budgetPeriod: { required: true, type: Number },
+    hash: { required: true, type: String },
+    feehash: { required: true, type: String },
+    url: { required: true, type: String }
+}, { versionKey: false }), 'proposals');
+
+module.exports = Proposal;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galilel-explorer",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Galilel Explorer",
   "main": "public",
   "repository": "git@github.com:Galilel-Project/galilel-explorer.git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cron:block": "node cron/block.js",
     "cron:coin": "node cron/coin.js",
     "cron:masternode": "node cron/masternode.js",
+    "cron:proposal": "node cron/proposal.js",
     "cron:peer": "node cron/peer.js",
     "cron:rich": "node cron/rich.js",
     "start:api": "node server/index.js",

--- a/public/img/governance_desktop.svg
+++ b/public/img/governance_desktop.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Ebene_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 48 48"
+   style="enable-background:new 0 0 48 48;"
+   xml:space="preserve"
+   sodipodi:docname="governance_desktop.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"><metadata
+   id="metadata14"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs12" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1054"
+   id="namedview10"
+   showgrid="false"
+   inkscape:zoom="9.3593832"
+   inkscape:cx="16.709768"
+   inkscape:cy="14.327839"
+   inkscape:window-x="1920"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Ebene_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:none;stroke:#795548;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#795548;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+
+<path
+   style="fill:#d5c6b6;stroke-width:0.13480505;fill-opacity:1"
+   d="M 0,34.09811 V 20.19622 H 24 48 V 34.09811 48 H 24 0 Z m 23.37625,6.35906 c 0.72329,-0.43329 1.21006,-1.11679 1.42379,-1.99923 0.0975,-0.40255 0.13472,-1.95561 0.10778,-4.49766 -0.0449,-4.23714 -0.077,-4.42743 -0.88523,-5.25363 -0.72198,-0.73801 -1.31162,-0.94538 -2.68926,-0.94579 -1.44105,-4.1e-4 -1.99003,0.19899 -2.7501,0.99899 -0.76404,0.80417 -0.8499,1.36412 -0.8499,5.5427 0,4.2712 0.0847,4.78867 0.92401,5.64663 0.72715,0.74328 1.42142,0.9652 2.88258,0.9214 1.04066,-0.0312 1.29321,-0.088 1.83633,-0.41341 z m -2.397,-1.88767 c -0.15121,-0.23929 -0.2216,-7.39303 -0.0795,-8.08315 0.0939,-0.45614 0.16548,-0.54518 0.43828,-0.54518 0.46233,0 0.49585,0.28032 0.50522,4.22509 0.009,3.91279 -0.0487,4.4784 -0.46576,4.53954 -0.15709,0.023 -0.33628,-0.0383 -0.3982,-0.1363 z m -5.24105,1.83217 c 0.003,-0.13118 0.34972,-2.98312 0.77119,-6.33763 l 0.76632,-6.09912 H 15.6404 c -1.58839,0 -1.63712,0.009 -1.69813,0.30666 -0.0634,0.30973 -0.41044,4.33524 -0.59037,6.84873 l -0.0976,1.36293 -0.10085,-1.0222 c -0.0555,-0.5622 -0.21799,-2.27949 -0.36116,-3.81621 -0.14316,-1.5367 -0.29273,-2.99333 -0.33236,-3.23695 l -0.0721,-0.44296 H 10.74951 9.11119 l 0.90309,6.30356 c 0.4967,3.46696 0.90666,6.31888 0.91102,6.33762 0.005,0.0187 1.08794,0.034 2.40794,0.034 2.19497,0 2.40042,-0.0204 2.40487,-0.23851 z M 30.53333,35.59734 V 30.55449 H 31.46667 32.4 V 29.25971 27.96492 H 29 25.6 v 1.29479 1.29478 h 0.93333 0.93334 v 5.04285 5.04284 H 29 30.53333 Z m 8,3.8162 V 38.1869 H 37.4 36.26667 v -1.43108 -1.43107 h 0.99999 1 v -1.22664 -1.22664 h -1 -0.99999 v -1.15275 -1.15276 l 1.03333,-0.0398 1.03333,-0.0399 0.0383,-1.26071 0.0384,-1.26071 h -2.60501 -2.605 v 6.33762 6.33764 h 2.66667 2.66667 z M 12.67532,15.52818 C 12.61042,15.35953 11.80186,13.35233 10.87862,11.06775 9.95538,8.78318 9.2,6.84769 9.2,6.76669 c 0,-0.0811 3.405,-1.57897 7.56666,-3.32877 8.92146,-3.75111 8.27185,-3.48728 8.36136,-3.39578 0.0781,0.0798 6.33865,15.61676 6.33865,15.7308 0,0.0385 -0.7568,0.0529 -1.68178,0.0319 l -1.68177,-0.0381 -2.24953,-5.58801 c -1.23723,-3.07341 -2.29543,-5.69317 -2.35155,-5.8217 -0.0896,-0.20519 -0.72008,0.0256 -5.16871,1.8929 -2.78666,1.16963 -5.08116,2.13803 -5.09887,2.15201 -0.0177,0.014 0.59591,1.57802 1.36361,3.47567 0.7677,1.89766 1.43123,3.56437 1.47453,3.70378 0.0739,0.23798 -0.0241,0.2535 -1.60025,0.2535 -1.61726,0 -1.68329,-0.0112 -1.79703,-0.30666 z"
+   id="path5149"
+   inkscape:connector-curvature="0" /></svg>

--- a/public/img/governance_mobile.svg
+++ b/public/img/governance_mobile.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Ebene_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 48 48"
+   style="enable-background:new 0 0 48 48;"
+   xml:space="preserve"
+   sodipodi:docname="governance_mobile.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14"><metadata
+   id="metadata14"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs12" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1054"
+   id="namedview10"
+   showgrid="false"
+   inkscape:zoom="9.3593832"
+   inkscape:cx="16.709768"
+   inkscape:cy="14.327839"
+   inkscape:window-x="1920"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Ebene_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:none;stroke:#795548;stroke-width:2;stroke-linecap:round;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#795548;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+
+<path
+   style="fill:#795548;stroke-width:0.13480505;fill-opacity:1"
+   d="M 0,34.09811 V 20.19622 H 24 48 V 34.09811 48 H 24 0 Z m 23.37625,6.35906 c 0.72329,-0.43329 1.21006,-1.11679 1.42379,-1.99923 0.0975,-0.40255 0.13472,-1.95561 0.10778,-4.49766 -0.0449,-4.23714 -0.077,-4.42743 -0.88523,-5.25363 -0.72198,-0.73801 -1.31162,-0.94538 -2.68926,-0.94579 -1.44105,-4.1e-4 -1.99003,0.19899 -2.7501,0.99899 -0.76404,0.80417 -0.8499,1.36412 -0.8499,5.5427 0,4.2712 0.0847,4.78867 0.92401,5.64663 0.72715,0.74328 1.42142,0.9652 2.88258,0.9214 1.04066,-0.0312 1.29321,-0.088 1.83633,-0.41341 z m -2.397,-1.88767 c -0.15121,-0.23929 -0.2216,-7.39303 -0.0795,-8.08315 0.0939,-0.45614 0.16548,-0.54518 0.43828,-0.54518 0.46233,0 0.49585,0.28032 0.50522,4.22509 0.009,3.91279 -0.0487,4.4784 -0.46576,4.53954 -0.15709,0.023 -0.33628,-0.0383 -0.3982,-0.1363 z m -5.24105,1.83217 c 0.003,-0.13118 0.34972,-2.98312 0.77119,-6.33763 l 0.76632,-6.09912 H 15.6404 c -1.58839,0 -1.63712,0.009 -1.69813,0.30666 -0.0634,0.30973 -0.41044,4.33524 -0.59037,6.84873 l -0.0976,1.36293 -0.10085,-1.0222 c -0.0555,-0.5622 -0.21799,-2.27949 -0.36116,-3.81621 -0.14316,-1.5367 -0.29273,-2.99333 -0.33236,-3.23695 l -0.0721,-0.44296 H 10.74951 9.11119 l 0.90309,6.30356 c 0.4967,3.46696 0.90666,6.31888 0.91102,6.33762 0.005,0.0187 1.08794,0.034 2.40794,0.034 2.19497,0 2.40042,-0.0204 2.40487,-0.23851 z M 30.53333,35.59734 V 30.55449 H 31.46667 32.4 V 29.25971 27.96492 H 29 25.6 v 1.29479 1.29478 h 0.93333 0.93334 v 5.04285 5.04284 H 29 30.53333 Z m 8,3.8162 V 38.1869 H 37.4 36.26667 v -1.43108 -1.43107 h 0.99999 1 v -1.22664 -1.22664 h -1 -0.99999 v -1.15275 -1.15276 l 1.03333,-0.0398 1.03333,-0.0399 0.0383,-1.26071 0.0384,-1.26071 h -2.60501 -2.605 v 6.33762 6.33764 h 2.66667 2.66667 z M 12.67532,15.52818 C 12.61042,15.35953 11.80186,13.35233 10.87862,11.06775 9.95538,8.78318 9.2,6.84769 9.2,6.76669 c 0,-0.0811 3.405,-1.57897 7.56666,-3.32877 8.92146,-3.75111 8.27185,-3.48728 8.36136,-3.39578 0.0781,0.0798 6.33865,15.61676 6.33865,15.7308 0,0.0385 -0.7568,0.0529 -1.68178,0.0319 l -1.68177,-0.0381 -2.24953,-5.58801 c -1.23723,-3.07341 -2.29543,-5.69317 -2.35155,-5.8217 -0.0896,-0.20519 -0.72008,0.0256 -5.16871,1.8929 -2.78666,1.16963 -5.08116,2.13803 -5.09887,2.15201 -0.0177,0.014 0.59591,1.57802 1.36361,3.47567 0.7677,1.89766 1.43123,3.56437 1.47453,3.70378 0.0739,0.23798 -0.0241,0.2535 -1.60025,0.2535 -1.61726,0 -1.68329,-0.0112 -1.79703,-0.30666 z"
+   id="path5149"
+   inkscape:connector-curvature="0" /></svg>

--- a/server/handler/blockex.js
+++ b/server/handler/blockex.js
@@ -1,4 +1,3 @@
-
 const chain = require('../../lib/blockchain');
 const { forEach } = require('p-iteration');
 const moment = require('moment');
@@ -10,6 +9,7 @@ const cache = require('../lib/cache');
 const Block = require('../../model/block');
 const Coin = require('../../model/coin');
 const Masternode = require('../../model/masternode');
+const Proposal = require('../../model/proposal');
 const Peer = require('../../model/peer');
 const Rich = require('../../model/rich');
 const BlockRewardDetails = require('../../model/blockRewardDetails');
@@ -107,47 +107,47 @@ const getAddress = async (req, res) => {
  * @param {Object} res The response object.
  */
 const getAvgBlockTime = () => {
-  // When does the cache expire.
-  // For now this is hard coded.
-  let cache = 90.0;
-  let cutOff = moment().utc().add(60, 'seconds').unix();
-  let loading = true;
+    // When does the cache expire.
+    // For now this is hard coded.
+    let cache = 90.0;
+    let cutOff = moment().utc().add(60, 'seconds').unix();
+    let loading = true;
 
-  // Generate the average.
-  const getAvg = async () => {
-    loading = true;
+    // Generate the average.
+    const getAvg = async() => {
+        loading = true;
 
-    try {
-      const date = moment.utc().subtract(24, 'hours').toDate();
-      const blocksCount = await Block.count({ createdAt: { $gt: date } });
-      const seconds = 24 * 60 * 60;
+        try {
+            const date = moment.utc().subtract(24, 'hours').toDate();
+            const blocksCount = await Block.count({ createdAt: { $gt: date } });
+            const seconds = 24 * 60 * 60;
 
-      cache = seconds / blocksCount;
-      cutOff = moment().utc().add(60, 'seconds').unix();
-    } catch (err) {
-      console.log(err);
-    } finally {
-      if (!cache) {
-        cache = 0.0;
-      }
+            cache = seconds / blocksCount;
+            cutOff = moment().utc().add(60, 'seconds').unix();
+        } catch (err) {
+            console.log(err);
+        } finally {
+            if (!cache) {
+                cache = 0.0;
+            }
 
-      loading = false;
-    }
-  };
+            loading = false;
+        }
+    };
 
-  // Load the initial cache.
-  getAvg();
+    // Load the initial cache.
+    getAvg();
 
-  return async (req, res) => {
-    res.json(cache || 0.0);
+    return async(req, res) => {
+        res.json(cache || 0.0);
 
-    // If the cache has expired then go ahead
-    // and get a new one but return the current
-    // cache for this request.
-    if (!loading && cutOff <= moment().utc().unix()) {
-      await getAvg();
-    }
-  };
+        // If the cache has expired then go ahead
+        // and get a new one but return the current
+        // cache for this request.
+        if (!loading && cutOff <= moment().utc().unix()) {
+            await getAvg();
+        }
+    };
 };
 
 /**
@@ -156,47 +156,47 @@ const getAvgBlockTime = () => {
  * @param {Object} res The response object.
  */
 const getAvgMNTime = () => {
-  // When does the cache expire.
-  // For now this is hard coded.
-  let cache = 24.0;
-  let cutOff = moment().utc().add(5, 'minutes').unix();
-  let loading = true;
+    // When does the cache expire.
+    // For now this is hard coded.
+    let cache = 24.0;
+    let cutOff = moment().utc().add(5, 'minutes').unix();
+    let loading = true;
 
-  // Generate the average.
-  const getAvg = async () => {
-    loading = true;
+    // Generate the average.
+    const getAvg = async() => {
+        loading = true;
 
-    try {
-      const date = moment.utc().subtract(24, 'hours').toDate();
-      const blocksCount = await Block.count({ createdAt: { $gt: date } });
-      const masternodesCount = await Masternode.count();
+        try {
+            const date = moment.utc().subtract(24, 'hours').toDate();
+            const blocksCount = await Block.count({ createdAt: { $gt: date } });
+            const masternodesCount = await Masternode.count();
 
-      cache = (24.0 / (blocksCount / masternodesCount));
-      cutOff = moment().utc().add(5, 'minutes').unix();
-    } catch (err) {
-      console.log(err);
-    } finally {
-      if (!cache) {
-        cache = 0.0;
-      }
+            cache = (24.0 / (blocksCount / masternodesCount));
+            cutOff = moment().utc().add(5, 'minutes').unix();
+        } catch (err) {
+            console.log(err);
+        } finally {
+            if (!cache) {
+                cache = 0.0;
+            }
 
-      loading = false;
-    }
-  };
+            loading = false;
+        }
+    };
 
-  // Load the initial cache.
-  getAvg();
+    // Load the initial cache.
+    getAvg();
 
-  return async (req, res) => {
-    res.json(cache || 0.0);
+    return async(req, res) => {
+        res.json(cache || 0.0);
 
-    // If the cache has expired then go ahead
-    // and get a new one but return the current
-    // cache for this request.
-    if (!loading && cutOff <= moment().utc().unix()) {
-      await getAvg();
-    }
-  };
+        // If the cache has expired then go ahead
+        // and get a new one but return the current
+        // cache for this request.
+        if (!loading && cutOff <= moment().utc().unix()) {
+            await getAvg();
+        }
+    };
 };
 
 /**
@@ -204,24 +204,22 @@ const getAvgMNTime = () => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getBlock = async (req, res) => {
-  try {
-    const query = isNaN(req.params.hash)
-      ? { hash: req.params.hash }
-      : { height: req.params.hash };
-    const block = await Block.findOne(query);
-    if (!block) {
-      res.status(404).send('Unable to find the block!');
-      return;
+const getBlock = async(req, res) => {
+    try {
+        const query = isNaN(req.params.hash) ? { hash: req.params.hash } : { height: req.params.hash };
+        const block = await Block.findOne(query);
+        if (!block) {
+            res.status(404).send('Unable to find the block!');
+            return;
+        }
+
+        const txs = await TX.find({ txId: { $in: block.txs } }, { involvedAddresses: 0 });
+
+        res.json({ block, txs });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
     }
-
-    const txs = await TX.find({ txId: { $in: block.txs } }, { involvedAddresses: 0 });
-
-    res.json({ block, txs });
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
 };
 
 /**
@@ -230,15 +228,15 @@ const getBlock = async (req, res) => {
  * @param {Object} res The response object.
  */
 const getCoin = (req, res) => {
-  Coin.findOne()
-    .sort({ createdAt: -1 })
-    .then((doc) => {
-      res.json(doc);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status(500).send(err.message || err);
-    });
+    Coin.findOne()
+        .sort({ createdAt: -1 })
+        .then((doc) => {
+            res.json(doc);
+        })
+        .catch((err) => {
+            console.log(err);
+            res.status(500).send(err.message || err);
+        });
 };
 
 /**
@@ -247,17 +245,17 @@ const getCoin = (req, res) => {
  * @param {Object} res The response object.
  */
 const getCoinHistory = (req, res) => {
-  Coin.find()
-    .skip(req.query.skip ? parseInt(req.query.skip, 10) : 0)
-    .limit(req.query.limit ? parseInt(req.query.limit, 10) : 12) // 12x5=60 mins
-    .sort({ createdAt: -1 })
-    .then((docs) => {
-      res.json(docs);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status(500).send(err.message || err);
-    });
+    Coin.find()
+        .skip(req.query.skip ? parseInt(req.query.skip, 10) : 0)
+        .limit(req.query.limit ? parseInt(req.query.limit, 10) : 12) // 12x5=60 mins
+        .sort({ createdAt: -1 })
+        .then((docs) => {
+            res.json(docs);
+        })
+        .catch((err) => {
+            console.log(err);
+            res.status(500).send(err.message || err);
+        });
 };
 
 /**
@@ -267,48 +265,48 @@ const getCoinHistory = (req, res) => {
  * @param {Object} res The response object.
  */
 const getCoinsWeek = () => {
-  // When does the cache expire.
-  // For now this is hard coded.
-  let cache = [];
-  let cutOff = moment().utc().add(1, 'hour').unix();
-  let loading = true;
+    // When does the cache expire.
+    // For now this is hard coded.
+    let cache = [];
+    let cutOff = moment().utc().add(1, 'hour').unix();
+    let loading = true;
 
-  // Aggregate the data and build the date list.
-  const getCoins = async () => {
-    loading = true;
+    // Aggregate the data and build the date list.
+    const getCoins = async() => {
+        loading = true;
 
-    try {
-      const start = moment().utc().subtract(8, 'days').toDate();
-      const end = moment().utc().toDate();
-      const qry = [
-        // Select last 7 days of coins.
-        { $match: { createdAt: { $gt: start, $lt: end } } },
-        // Sort by _id/date field in ascending order (order -> newer)
-        { $sort: { createdAt: 1 } }
-      ];
+        try {
+            const start = moment().utc().subtract(8, 'days').toDate();
+            const end = moment().utc().toDate();
+            const qry = [
+                // Select last 7 days of coins.
+                { $match: { createdAt: { $gt: start, $lt: end } } },
+                // Sort by _id/date field in ascending order (order -> newer)
+                { $sort: { createdAt: 1 } }
+            ];
 
-      cache = await Coin.aggregate(qry);
-      cutOff = moment().utc().add(90, 'seconds').unix();
-    } catch (err) {
-      console.log(err);
-    } finally {
-      loading = false;
-    }
-  };
+            cache = await Coin.aggregate(qry);
+            cutOff = moment().utc().add(90, 'seconds').unix();
+        } catch (err) {
+            console.log(err);
+        } finally {
+            loading = false;
+        }
+    };
 
-  // Load the initial cache.
-  getCoins();
+    // Load the initial cache.
+    getCoins();
 
-  return async (req, res) => {
-    res.json(cache);
+    return async(req, res) => {
+        res.json(cache);
 
-    // If the cache has expired then go ahead
-    // and get a new one but return the current
-    // cache for this request.
-    if (!loading && cutOff <= moment().utc().unix()) {
-      await getCoins();
-    }
-  };
+        // If the cache has expired then go ahead
+        // and get a new one but return the current
+        // cache for this request.
+        if (!loading && cutOff <= moment().utc().unix()) {
+            await getCoins();
+        }
+    };
 };
 
 /**
@@ -316,21 +314,21 @@ const getCoinsWeek = () => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getIsBlock = async (req, res) => {
-  try {
-    let isBlock = false;
+const getIsBlock = async(req, res) => {
+    try {
+        let isBlock = false;
 
-    // Search for block hash.
-    const block = await Block.findOne({ hash: req.params.hash });
-    if (block) {
-      isBlock = true;
+        // Search for block hash.
+        const block = await Block.findOne({ hash: req.params.hash });
+        if (block) {
+            isBlock = true;
+        }
+
+        res.json(isBlock);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
     }
-
-    res.json(isBlock);
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
 };
 
 /**
@@ -338,36 +336,36 @@ const getIsBlock = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getMasternodes = async (req, res) => {
-  try {
-    const limit = req.query.limit ? parseInt(req.query.limit, 10) : 1000;
-    const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
+const getMasternodes = async(req, res) => {
+    try {
+        const limit = req.query.limit ? parseInt(req.query.limit, 10) : 1000;
+        const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
 
-    var query = {};
+        var query = {};
 
-    // Optionally it's possible to filter masternodes running on a specific address
-    if (req.query.hash) {
-      query.addr = req.query.hash;
+        // Optionally it's possible to filter masternodes running on a specific address
+        if (req.query.hash) {
+            query.addr = req.query.hash;
+        }
+
+        // Optionally it's possible to filter masternodes running on a specific range of addresses. Pass in addresses as comma-seprated list
+        // In redux we pass in an array and it automatically converts into a comma-seperated list of addresses
+        if (req.query.addresses) {
+            const addressList = req.query.addresses.split(',');
+            // At the moment the limit of addresses in a single query is 25 but this number will be increased later, perhaps with some form of caching
+            if (addressList.length < 25) {
+                query.addr = { "$in": addressList };
+            }
+        }
+
+        const total = await Masternode.count(query);
+        const mns = await Masternode.find(query).skip(skip).limit(limit).sort({ lastPaidAt: -1, status: 1 });
+
+        res.json({ mns, pages: total <= limit ? 1 : Math.ceil(total / limit) });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
     }
-
-    // Optionally it's possible to filter masternodes running on a specific range of addresses. Pass in addresses as comma-seprated list
-    // In redux we pass in an array and it automatically converts into a comma-seperated list of addresses
-    if (req.query.addresses) {
-      const addressList = req.query.addresses.split(',');
-      // At the moment the limit of addresses in a single query is 25 but this number will be increased later, perhaps with some form of caching
-      if (addressList.length < 25) {
-        query.addr = { "$in": addressList };
-      }
-    }
-
-    const total = await Masternode.count(query);
-    const mns = await Masternode.find(query).skip(skip).limit(limit).sort({ lastPaidAt: -1, status: 1 });
-
-    res.json({ mns, pages: total <= limit ? 1 : Math.ceil(total / limit) });
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
 };
 
 /**
@@ -375,16 +373,35 @@ const getMasternodes = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getMasternodeByAddress = async (req, res) => {
-  try {
-    const hash = req.params.hash;
-    const mns = await Masternode.findOne({ addr: hash });
+const getMasternodeByAddress = async(req, res) => {
+    try {
+        const hash = req.params.hash;
+        const mns = await Masternode.findOne({ addr: hash });
 
-    res.json({ mns });
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        res.json({ mns });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
+};
+
+/**
+ * Get Proposals Data from the server.
+ * @param {Object} req The request object.
+ * @param {Object} res The response object.
+ */
+const getProposals = async(req, res) => {
+    try {
+        const limit = req.query.limit ? parseInt(req.query.limit, 10) : 1000;
+        const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
+        const total = await Proposal.count();
+        const pps = await Proposal.find().skip(skip).limit(limit);
+
+        res.json({ pps, pages: total <= limit ? 1 : Math.ceil(total / limit) });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
 
 /**
@@ -392,18 +409,18 @@ const getMasternodeByAddress = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getMasternodeCount = async (req, res) => {
-  try {
-    const masternodeCount = await cache.getFromCache("masternodeCount", moment().utc().add(60, 'seconds').unix(), async () => {
-      const coin = await Coin.findOne().sort({ createdAt: -1 });
-      return { enabled: coin.mnsOn, total: coin.mnsOff + coin.mnsOn };
-    });
+const getMasternodeCount = async(req, res) => {
+    try {
+        const masternodeCount = await cache.getFromCache("masternodeCount", moment().utc().add(60, 'seconds').unix(), async() => {
+            const coin = await Coin.findOne().sort({ createdAt: -1 });
+            return { enabled: coin.mnsOn, total: coin.mnsOff + coin.mnsOn };
+        });
 
-    res.json(masternodeCount);
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        res.json(masternodeCount);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
 
 /**
@@ -412,17 +429,17 @@ const getMasternodeCount = async (req, res) => {
  * @param {Object} res The response object.
  */
 const getPeer = (req, res) => {
-  Peer.find()
-    .skip(req.query.skip ? parseInt(req.query.skip, 10) : 0)
-    .limit(req.query.limit ? parseInt(req.query.limit, 10) : 500)
-    .sort({ ip: 1 })
-    .then((docs) => {
-      res.json(docs);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status(500).send(err.message || err);
-    });
+    Peer.find()
+        .skip(req.query.skip ? parseInt(req.query.skip, 10) : 0)
+        .limit(req.query.limit ? parseInt(req.query.limit, 10) : 500)
+        .sort({ ip: 1 })
+        .then((docs) => {
+            res.json(docs);
+        })
+        .catch((err) => {
+            console.log(err);
+            res.status(500).send(err.message || err);
+        });
 };
 
 /**
@@ -456,19 +473,19 @@ const getSupply = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getTop100 = async (req, res) => {
-  try {
-    const docs = await cache.getFromCache("top100", moment().utc().add(1, 'hours').unix(), async () => {
-      return await Rich.find()
-        .limit(100)
-        .sort({ value: -1 });
-    });
+const getTop100 = async(req, res) => {
+    try {
+        const docs = await cache.getFromCache("top100", moment().utc().add(1, 'hours').unix(), async() => {
+            return await Rich.find()
+                .limit(100)
+                .sort({ value: -1 });
+        });
 
-    res.json(docs);
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        res.json(docs);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
 
 /**
@@ -476,20 +493,20 @@ const getTop100 = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getTXLatest = async (req, res) => {
-  try {
-    const docs = await cache.getFromCache("txLatest", moment().utc().add(90, 'seconds').unix(), async () => {
-      return await TX.find({}, { involvedAddresses: 0 }) // Don't include involvedAddresses for txs as 1000 inputs would give 1000 extra addresses
-        .populate('blockRewardDetails')
-        .limit(10)
-        .sort({ blockHeight: -1 });
-    });
+const getTXLatest = async(req, res) => {
+    try {
+        const docs = await cache.getFromCache("txLatest", moment().utc().add(90, 'seconds').unix(), async() => {
+            return await TX.find({}, { involvedAddresses: 0 }) // Don't include involvedAddresses for txs as 1000 inputs would give 1000 extra addresses
+                .populate('blockRewardDetails')
+                .limit(10)
+                .sort({ blockHeight: -1 });
+        });
 
-    res.json(docs);
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        res.json(docs);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
 
 /**
@@ -497,22 +514,20 @@ const getTXLatest = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getTX = async (req, res) => {
-  try {
-    const query = isNaN(req.params.hash)
-      ? { txId: req.params.hash }
-      : { height: req.params.hash };
-    const tx = await TX.findOne(query).populate('blockRewardDetails');
-    if (!tx) {
-      res.status(404).send('Unable to find the transaction!');
-      return;
+const getTX = async(req, res) => {
+    try {
+        const query = isNaN(req.params.hash) ? { txId: req.params.hash } : { height: req.params.hash };
+        const tx = await TX.findOne(query).populate('blockRewardDetails');
+        if (!tx) {
+            res.status(404).send('Unable to find the transaction!');
+            return;
+        }
+
+        res.json(tx);
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
     }
-
-    res.json(tx);
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
 };
 
 /**
@@ -520,21 +535,21 @@ const getTX = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getTXs = async (req, res) => {
-  try {
-    const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
-    const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
+const getTXs = async(req, res) => {
+    try {
+        const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
+        const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
 
-    const total = await TX.count();
-    const txs = await TX.find({}, { involvedAddresses: 0 }).populate('blockRewardDetails').skip(skip).limit(limit).sort({ blockHeight: -1 });
-    
-    //@todo If instant load txs get abused with mass input/output spam then we can output ones where inputs<=3 and outputs<=3
+        const total = await TX.count();
+        const txs = await TX.find({}, { involvedAddresses: 0 }).populate('blockRewardDetails').skip(skip).limit(limit).sort({ blockHeight: -1 });
 
-    res.json({ txs, pages: total <= limit ? 1 : Math.ceil(total / limit) });
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        //@todo If instant load txs get abused with mass input/output spam then we can output ones where inputs<=3 and outputs<=3
+
+        res.json({ txs, pages: total <= limit ? 1 : Math.ceil(total / limit) });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
 
 /**
@@ -542,22 +557,20 @@ const getTXs = async (req, res) => {
  * @param {Object} req The request object.
  * @param {Object} res The response object.
  */
-const getRewards = async (req, res) => {
-  try {
-    const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
-    const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
+const getRewards = async(req, res) => {
+    try {
+        const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
+        const skip = req.query.skip ? parseInt(req.query.skip, 10) : 0;
 
-    const total = await BlockRewardDetails.count();
-    const rewards = await BlockRewardDetails.find().skip(skip).limit(limit).sort({ blockHeight: -1 });
-    
-    res.json({ rewards, pages: total <= limit ? 1 : Math.ceil(total / limit) });
-  } catch (err) {
-    console.log(err);
-    res.status(500).send(err.message || err);
-  }
+        const total = await BlockRewardDetails.count();
+        const rewards = await BlockRewardDetails.find().skip(skip).limit(limit).sort({ blockHeight: -1 });
+
+        res.json({ rewards, pages: total <= limit ? 1 : Math.ceil(total / limit) });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err.message || err);
+    }
 };
-
-
 
 /**
  * Return all the transactions for an entire week.
@@ -566,72 +579,73 @@ const getRewards = async (req, res) => {
  * @param {Object} res The response object.
  */
 const getTXsWeek = () => {
-  // When does the cache expire.
-  // For now this is hard coded.
-  let cache = [];
-  let cutOff = moment().utc().add(1, 'hour').unix();
-  let loading = true;
+    // When does the cache expire.
+    // For now this is hard coded.
+    let cache = [];
+    let cutOff = moment().utc().add(1, 'hour').unix();
+    let loading = true;
 
-  // Aggregate the data and build the date list.
-  const getTXs = async () => {
-    loading = true;
+    // Aggregate the data and build the date list.
+    const getTXs = async() => {
+        loading = true;
 
-    try {
-      const start = moment().utc().startOf('day').subtract(7, 'days').toDate();
-      const end = moment().utc().endOf('day').subtract(1, 'days').toDate();
-      const qry = [
-        // Select last 7 days of txs.
-        { $match: { createdAt: { $gt: start, $lt: end } } },
-        // Convert createdAt date field to date string.
-        { $project: { date: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } } } },
-        // Group by date string and build total/sum.
-        { $group: { _id: '$date', total: { $sum: 1 } } },
-        // Sort by _id/date field in ascending order (order -> newer)
-        { $sort: { _id: 1 } }
-      ];
+        try {
+            const start = moment().utc().startOf('day').subtract(7, 'days').toDate();
+            const end = moment().utc().endOf('day').subtract(1, 'days').toDate();
+            const qry = [
+                // Select last 7 days of txs.
+                { $match: { createdAt: { $gt: start, $lt: end } } },
+                // Convert createdAt date field to date string.
+                { $project: { date: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } } } },
+                // Group by date string and build total/sum.
+                { $group: { _id: '$date', total: { $sum: 1 } } },
+                // Sort by _id/date field in ascending order (order -> newer)
+                { $sort: { _id: 1 } }
+            ];
 
-      cache = await TX.aggregate(qry);
-      cutOff = moment().utc().add(90, 'seconds').unix();
-    } catch (err) {
-      console.log(err);
-    } finally {
-      loading = false;
-    }
-  };
+            cache = await TX.aggregate(qry);
+            cutOff = moment().utc().add(90, 'seconds').unix();
+        } catch (err) {
+            console.log(err);
+        } finally {
+            loading = false;
+        }
+    };
 
-  // Load the initial cache.
-  getTXs();
+    // Load the initial cache.
+    getTXs();
 
-  return async (req, res) => {
-    res.json(cache);
+    return async(req, res) => {
+        res.json(cache);
 
-    // If the cache has expired then go ahead
-    // and get a new one but return the current
-    // cache for this request.
-    if (!loading && cutOff <= moment().utc().unix()) {
-      await getTXs();
-    }
-  };
+        // If the cache has expired then go ahead
+        // and get a new one but return the current
+        // cache for this request.
+        if (!loading && cutOff <= moment().utc().unix()) {
+            await getTXs();
+        }
+    };
 };
 
 module.exports = {
-  getAddress,
-  getAvgBlockTime,
-  getAvgMNTime,
-  getBlock,
-  getCoin,
-  getCoinHistory,
-  getCoinsWeek,
-  getIsBlock,
-  getMasternodes,
-  getMasternodeByAddress,
-  getMasternodeCount,
-  getPeer,
-  getSupply,
-  getTop100,
-  getTXLatest,
-  getTX,
-  getTXs,
-  getRewards,
-  getTXsWeek
+    getAddress,
+    getAvgBlockTime,
+    getAvgMNTime,
+    getBlock,
+    getCoin,
+    getCoinHistory,
+    getCoinsWeek,
+    getIsBlock,
+    getMasternodes,
+    getMasternodeByAddress,
+    getProposals,
+    getMasternodeCount,
+    getPeer,
+    getSupply,
+    getTop100,
+    getTXLatest,
+    getTX,
+    getTXs,
+    getRewards,
+    getTXsWeek
 };

--- a/server/route/api.js
+++ b/server/route/api.js
@@ -1,4 +1,3 @@
-
 const express = require('express');
 const blockex = require('../handler/blockex');
 const iquidus = require('../handler/iquidus');
@@ -12,6 +11,7 @@ router.get('/block/:hash', blockex.getBlock);
 router.get('/coin', blockex.getCoin);
 router.get('/coin/history', blockex.getCoinHistory);
 router.get('/coin/week', blockex.getCoinsWeek());
+router.get('/proposals', blockex.getProposals);
 router.get('/masternode', blockex.getMasternodes);
 router.get('/masternode/average', blockex.getAvgMNTime());
 router.get('/masternode/:hash', blockex.getMasternodeByAddress);
@@ -34,4 +34,4 @@ router.get('/getblock', iquidus.getblock);
 router.get('/getrawtransaction', iquidus.getrawtransaction);
 router.get('/getnetworkhashps', iquidus.getnetworkhashps);
 
-module.exports =  router;
+module.exports = router;


### PR DESCRIPTION
We added support to show budget proposals for governance purposes in a separate table. The left menu got a new icon:

![image](https://user-images.githubusercontent.com/936659/62076213-621cfd80-b247-11e9-9640-a443fec07ffd.png)

Once user click on this icon, they can see the current running budget proposals. This is necessary requirement for proper DAO implementation and transparency.

In Bulwark there is already a PR (https://github.com/bulwark-crypto/bulwark-explorer/pull/131) open for this feature. I don't want to make work from @akshaynexus and @hodlforjesus useless. But feel free to adopt the changes if needed, differences compared to [Bulwark PR 131](https://github.com/bulwark-crypto/bulwark-explorer/pull/131):

1. We removed `created` column because it is mis-leading, it refers to last db update time.
2. We introduced storing of `blockStart` and `blockEnd`, in case of budget proposals running for several months it is needed.
3. We show information about payout amounts, this is what everybody wants to know.
4. We show payout amounts in relation to budget period, so monthly payout, already paid budget and total budget over the proposal period.
5. We use same throttle mechanism as for masternode list which makes client rendering ~4 times faster.