### PR TITLE
Added CoinGecko API support and new RPC command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 
 Simple and beautiful cryptocurrency block explorer system. It includes a
 Proof-of-Stake calculator, masternode statistics and market statistics based
-on CoinMarketCap (https://coinmarketcap.com/currencies/galilel/) data. Many
-thanks for the original version to the Bulwark developers.
+on CoinMarketCap (https://coinmarketcap.com/currencies/galilel/) or CoinGecko
+(https://www.coingecko.com/coins/galilel) data. Many thanks for the original
+version to the Bulwark developers.
 
 ## Requirements
 
@@ -76,7 +77,8 @@ The following automated tasks are currently needed for Galilel Explorer to
 update. First time you need to do initial sync of the blockchain via
 `npm run cron:block`, takes a lot of time.
 
-1. Fetch coin related information like price and supply from CoinMarketCap.
+1. Fetch coin related information like price and supply from CoinMarketCap or
+   CoinGecko.
 
    `npm run cron:coin`
 

--- a/client/component/Card/CardMarket.jsx
+++ b/client/component/Card/CardMarket.jsx
@@ -58,7 +58,7 @@ export default class CardStatus extends Component {
               </span>
               <span>In { this.props.xAxis.length * 5 } minutes</span>
             </p>
-            <p className="card__info-source">Data from CoinMarketCap</p>
+            <p className="card__info-source">Data from { config.apiProvider }</p>
           </div>
           <div className="col-sm-12 col-md-6 col-lg-8">
             <GraphLine

--- a/config.template.js
+++ b/config.template.js
@@ -47,10 +47,23 @@ const config = {
   freegeoip: {
     'api': 'https://extreme-ip-lookup.com/json/'
   },
+
+  /**
+   * API markets.
+   */
   coinMarketCap: {
     'api': 'https://api.coinmarketcap.com/v1/ticker/',
     'ticker': 'galilel'
   },
+  coinGecko: {
+    'api': 'https://api.coingecko.com/api/v3/coins/',
+    'ticker': 'galilel'
+  },
+
+  /**
+   * Specify the market API provider (coinMarketCap and coinGecko are supported).
+   */
+  apiProvider: 'CoinMarketCap',
 
   /**
    * All links to website and social media.

--- a/config.template.js
+++ b/config.template.js
@@ -11,6 +11,17 @@ const config = {
   },
 
   /**
+   * Specify the RPC-API of the coin daemon. The following options are available:
+   *
+   * modern (default)
+   * - getmasternodecount, listmasternodes, getbudgetinfo and getmasternodecount
+   *
+   * legacy
+   * - masternode, masternodelist, mnbudget
+   */
+  rpcApi: 'modern',
+
+  /**
    * If set to true there are extra logging details in cron scripts.
    */
   verboseCron: true,

--- a/cron/coin.js
+++ b/cron/coin.js
@@ -23,9 +23,33 @@ async function syncCoin() {
    */
   const provider = `${ config.apiProvider }`;
 
+  /**
+   * Get RPC-API model.
+   */
+  const rpcApi = `${ config.rpcApi }`;
+
   const info = await rpc.call('getinfo');
-  const masternodes = await rpc.call('getmasternodecount');
   const nethashps = await rpc.call('getnetworkhashps');
+
+  /* shared variables. */
+  let mnsOff;
+  let mnsOn;
+  let supply;
+
+  if (rpcApi === "modern") {
+    const masternodes = await rpc.call('getmasternodecount');
+    mnsOff = masternodes.total - masternodes.stable;
+    mnsOn = masternodes.stable;
+    supply = info.moneysupply;
+  }
+
+  if (rpcApi === "legacy") {
+    const masternodes = await rpc.call('masternode', ['count']);
+    const txoutsetinfo = await rpc.call('gettxoutsetinfo');
+    mnsOff = masternodes;
+    mnsOn = masternodes;
+    supply = txoutsetinfo.total_amount;
+  }
 
   /**
    * CoinMarketCap
@@ -43,12 +67,12 @@ async function syncCoin() {
       blocks: info.blocks,
       btc: market.price_btc,
       diff: info.difficulty,
-      mnsOff: masternodes.total - masternodes.stable,
-      mnsOn: masternodes.stable,
+      mnsOff: mnsOff,
+      mnsOn: mnsOn,
       netHash: nethashps,
       peers: info.connections,
       status: 'Online',
-      supply: info.moneysupply,
+      supply: supply,
       usd: market.price_usd
     });
 
@@ -71,12 +95,12 @@ async function syncCoin() {
       blocks: info.blocks,
       btc: market.market_data.current_price.btc,
       diff: info.difficulty,
-      mnsOff: masternodes.total - masternodes.stable,
-      mnsOn: masternodes.stable,
+      mnsOff: mnsOff,
+      mnsOn: mnsOn,
       netHash: nethashps,
       peers: info.connections,
       status: 'Online',
-      supply: info.moneysupply,
+      supply: supply,
       usd: market.market_data.current_price.usd
     });
 

--- a/cron/coin.js
+++ b/cron/coin.js
@@ -19,35 +19,69 @@ async function syncCoin() {
   const date = moment().utc().startOf('minute').toDate();
 
   /**
-   * Setup the coinmarketcap.com api url.
+   * Setup the market api url.
    */
-  const url = `${ config.coinMarketCap.api }${ config.coinMarketCap.ticker }`;
+  const provider = `${ config.apiProvider }`;
 
   const info = await rpc.call('getinfo');
   const masternodes = await rpc.call('getmasternodecount');
   const nethashps = await rpc.call('getnetworkhashps');
 
-  let market = await fetch(url);
-  if (Array.isArray(market)) {
-    market = market.length ? market[0] : {};
+  /**
+   * CoinMarketCap
+   */
+  if (provider === "CoinMarketCap") {
+    const url = `${ config.coinMarketCap.api }${ config.coinMarketCap.ticker }`;
+    let market = await fetch(url);
+    if (Array.isArray(market)) {
+      market = market.length ? market[0] : {};
+    }
+
+    const coin = new Coin({
+      cap: market.market_cap_usd,
+      createdAt: date,
+      blocks: info.blocks,
+      btc: market.price_btc,
+      diff: info.difficulty,
+      mnsOff: masternodes.total - masternodes.stable,
+      mnsOn: masternodes.stable,
+      netHash: nethashps,
+      peers: info.connections,
+      status: 'Online',
+      supply: info.moneysupply,
+      usd: market.price_usd
+    });
+
+    await coin.save();
   }
 
-  const coin = new Coin({
-    cap: market.market_cap_usd,
-    createdAt: date,
-    blocks: info.blocks,
-    btc: market.price_btc,
-    diff: info.difficulty,
-    mnsOff: masternodes.total - masternodes.stable,
-    mnsOn: masternodes.stable,
-    netHash: nethashps,
-    peers: info.connections,
-    status: 'Online',
-    supply: info.moneysupply,
-    usd: market.price_usd
-  });
+  /**
+   * CoinGecko
+   */
+  if (provider === "CoinGecko") {
+    const url = `${ config.coinGecko.api }${ config.coinGecko.ticker }`;
+    let market = await fetch(url);
+    if (Array.isArray(market)) {
+      market = market.length ? market[0] : {};
+    }
 
-  await coin.save();
+    const coin = new Coin({
+      cap: market.market_data.market_cap.usd,
+      createdAt: date,
+      blocks: info.blocks,
+      btc: market.market_data.current_price.btc,
+      diff: info.difficulty,
+      mnsOff: masternodes.total - masternodes.stable,
+      mnsOn: masternodes.stable,
+      netHash: nethashps,
+      peers: info.connections,
+      status: 'Online',
+      supply: info.moneysupply,
+      usd: market.market_data.current_price.usd
+    });
+
+    await coin.save();
+  }
 }
 
 /**

--- a/cron/masternode.js
+++ b/cron/masternode.js
@@ -22,7 +22,7 @@ async function syncMasternode() {
   // Increase the timeout for masternode.
   rpc.timeout(10000); // 10 secs
 
-  const mns = await rpc.call('masternode', ['list']);
+  const mns = await rpc.call('listmasternodes');
   const inserts = [];
   await forEach(mns, async (mn) => {
     const masternode = new Masternode({

--- a/cron/masternode.js
+++ b/cron/masternode.js
@@ -1,6 +1,7 @@
 require('babel-polyfill');
 require('../lib/cron');
 
+const config = require('../public/config');
 const { exit, rpc } = require('../lib/cron');
 const fetch = require('../lib/fetch');
 const { forEach } = require('p-iteration');
@@ -16,31 +17,63 @@ const Masternode = require('../model/masternode');
  */
 async function syncMasternode() {
   const date = moment().utc().startOf('minute').toDate();
+  const inserts = [];
+
+  /**
+   * Get RPC-API model.
+   */
+  const rpcApi = `${ config.rpcApi }`;
 
   await Masternode.remove({});
 
   // Increase the timeout for masternode.
   rpc.timeout(10000); // 10 secs
 
-  const mns = await rpc.call('listmasternodes');
-  const inserts = [];
-  await forEach(mns, async (mn) => {
-    const masternode = new Masternode({
-      active: mn.activetime,
-      addr: mn.addr,
-      createdAt: date,
-      lastAt: new Date(mn.lastseen * 1000),
-      lastPaidAt: new Date(mn.lastpaid * 1000),
-      network: mn.network,
-      rank: mn.rank,
-      status: mn.status,
-      txHash: mn.txhash,
-      txOutIdx: mn.outidx,
-      ver: mn.version
-    });
 
-    inserts.push(masternode);
-  });
+  if (rpcApi === "modern") {
+    const mns = await rpc.call('listmasternodes');
+    await forEach(mns, async (mn) => {
+      const masternode = new Masternode({
+        active: mn.activetime,
+        addr: mn.addr,
+        createdAt: date,
+        lastAt: new Date(mn.lastseen * 1000),
+        lastPaidAt: new Date(mn.lastpaid * 1000),
+        network: mn.network,
+        rank: mn.rank,
+        status: mn.status,
+        txHash: mn.txhash,
+        txOutIdx: mn.outidx,
+        ver: mn.version
+      });
+
+      inserts.push(masternode);
+    });
+  }
+
+  if (rpcApi === "legacy") {
+    const mns = await rpc.call('masternodelist', ['full']);
+    for (const prop in mns) {
+      mn = mns[prop].split(' ').filter(e => String(e).trim());
+      tx = prop.split('-');
+
+      const masternode = new Masternode({
+        active: mn[5],
+        addr: mn[2],
+        createdAt: date,
+        lastAt: new Date(mn[4] * 1000),
+        lastPaidAt: new Date(mn[6] * 1000),
+        network: "ipv4", // getting network in legacy codebase is impossible, assume ipv4.
+        rank: 0, // getting rank in legacy codebase is a very expensive call, skip it since it is not shown in frontend.
+        status: mn[0],
+        txHash: tx[0],
+        txOutIdx: tx[1],
+        ver: mn[1]
+      });
+
+      inserts.push(masternode);
+    }
+  }
 
   if (inserts.length) {
     await Masternode.insertMany(inserts);

--- a/cron/proposal.js
+++ b/cron/proposal.js
@@ -10,31 +10,62 @@ const moment = require('moment');
 const Proposal = require('../model/proposal');
 
 async function syncProposal() {
+    const inserts = [];
+
+    /**
+     * Get RPC-API model.
+     */
+    const rpcApi = `${ config.rpcApi }`;
+
     await Proposal.remove({});
 
     rpc.timeout(10000); // 10 secs
 
-    const pps = await rpc.call('getbudgetinfo');
-    const mnc = await rpc.call('getmasternodecount');
-    const inserts = [];
-    await forEach(pps, async(pp) => {
-        const proposal = new Proposal({
-            name: pp.Name,
-            yeas: pp.Yeas,
-            nays: pp.Nays,
-            blockStart: pp.BlockStart,
-            blockEnd: pp.BlockEnd,
-            status: ((pp.Yeas - pp.Nays) * 10 > mnc.total),
-            budgetTotal: pp.TotalPayment,
-            budgetMonthly: pp.MonthlyPayment,
-            budgetPeriod: pp.RemainingPaymentCount,
-            hash: pp.Hash,
-            feehash: pp.FeeHash,
-            url: pp.URL,
-        });
+    if (rpcApi === "modern") {
+        const pps = await rpc.call('getbudgetinfo');
+        const mnc = await rpc.call('getmasternodecount');
+        await forEach(pps, async(pp) => {
+            const proposal = new Proposal({
+                name: pp.Name,
+                yeas: pp.Yeas,
+                nays: pp.Nays,
+                blockStart: pp.BlockStart,
+                blockEnd: pp.BlockEnd,
+                status: ((pp.Yeas - pp.Nays) * 10 > mnc.total),
+                budgetTotal: pp.TotalPayment,
+                budgetMonthly: pp.MonthlyPayment,
+                budgetPeriod: pp.RemainingPaymentCount,
+                hash: pp.Hash,
+                feehash: pp.FeeHash,
+                url: pp.URL,
+            });
 
-        inserts.push(proposal);
-    });
+            inserts.push(proposal);
+        });
+    }
+
+    if (rpcApi === "legacy") {
+        const pps = await rpc.call('mnbudget', ['show']);
+        const mnc = await rpc.call('masternode', ['count']);
+        for (const prop in pps) {
+            const proposal = new Proposal({
+                name: pps[prop].Name,
+                yeas: pps[prop].Yeas,
+                nays: pps[prop].Nays,
+                blockStart: pps[prop].BlockStart,
+                blockEnd: pps[prop].BlockEnd,
+                status: ((pps[prop].Yeas - pps[prop].Nays) * 10 > mnc),
+                budgetTotal: pps[prop].TotalPayment,
+                budgetMonthly: pps[prop].MonthlyPayment,
+                budgetPeriod: pps[prop].RemainingPaymentCount,
+                hash: pps[prop].Hash,
+                feehash: pps[prop].FeeHash,
+                url: pps[prop].URL,
+            });
+
+            inserts.push(proposal);
+        }
+    }
 
     if (inserts.length) {
         await Proposal.insertMany(inserts);


### PR DESCRIPTION
This PR adds support to configure market data API provider. Original version supports only CoinMarketCap API which limits the explorer to certain coins only. We've added a pluggable architecture and extended it already with CoinGecko API support.

Beside this we've added support for `listmasternodes` which replaced deprecated `masternode list` command.